### PR TITLE
FEAT - truncate long worker names in injury register worker cell

### DIFF
--- a/resources/js/components/injury-register/InjuryWorkerCell.tsx
+++ b/resources/js/components/injury-register/InjuryWorkerCell.tsx
@@ -19,7 +19,9 @@ export default function InjuryWorkerCell({ employee, fallbackName }: InjuryWorke
                 <AvatarFallback>{getInitials(displayName)}</AvatarFallback>
             </Avatar>
             <div>
-                <div className="text-xs font-medium leading-tight">{displayName}</div>
+              <div className="text-xs font-medium leading-tight">
+  {displayName.length > 20 ? `${displayName.slice(0, 20)}...` : displayName}
+</div>
                 {employee?.employment_type && (
                     <div className="text-muted-foreground text-xs leading-tight">{employee.employment_type}</div>
                 )}


### PR DESCRIPTION
## Summary
Truncate worker display names longer than 20 characters with an ellipsis
in InjuryWorkerCell so long names don't stretch the injury register table.

## Changes
- resources/js/components/injury-register/InjuryWorkerCell.tsx: render
  the first 20 characters + "..." when the name exceeds 20 characters.
