### PR TITLE
FEAT - add item-level PPE issuance reasons

### DIFF
--- a/app/Http/Controllers/PpeFormController.php
+++ b/app/Http/Controllers/PpeFormController.php
@@ -172,15 +172,15 @@ class PpeFormController extends Controller
         $itemKeys = collect(PpeIssuance::PPE_CATALOG)->pluck('key')->all();
 
         $rules = [
-            'reason' => ['required', 'string', 'in:' . implode(',', array_keys(PpeIssuance::REASON_OPTIONS))],
             'issued_items' => 'required|array|min:1',
-            'issued_items.*.key' => ['required', 'string', 'in:' . implode(',', $itemKeys)],
+            'issued_items.*.key' => ['required', 'string', 'in:'.implode(',', $itemKeys)],
             'issued_items.*.qty' => 'required|integer|min:1|max:50',
+            'issued_items.*.reason' => ['required', 'string', 'in:'.implode(',', array_keys(PpeIssuance::REASON_OPTIONS))],
             'issued_items.*.size' => 'nullable|string|max:8',
             'issued_items.*.make_model' => 'nullable|string|max:255',
             'fit_test_completed' => 'nullable|boolean',
             'authorised_by_user_id' => 'required|integer|exists:users,id',
-            'ppe_returned' => ['required', 'string', 'in:' . implode(',', array_keys(PpeIssuance::RETURNED_OPTIONS))],
+            'ppe_returned' => ['required', 'string', 'in:'.implode(',', array_keys(PpeIssuance::RETURNED_OPTIONS))],
         ];
 
         if (! $preAuthedEmployee) {
@@ -202,12 +202,15 @@ class PpeFormController extends Controller
 
         $this->guardAuthorisedBy($location, (int) $data['authorised_by_user_id']);
 
-        $issuance = DB::transaction(function () use ($data, $location, $employee, $source) {
+        $issuedItems = $this->normaliseItems($data['issued_items']);
+        $summaryReason = PpeIssuance::summariseItemReasons($issuedItems);
+
+        $issuance = DB::transaction(function () use ($data, $issuedItems, $summaryReason, $location, $employee, $source) {
             return PpeIssuance::create([
                 'location_id' => $location->id,
                 'employee_id' => $employee->id,
-                'reason' => $data['reason'],
-                'issued_items' => $this->normaliseItems($data['issued_items']),
+                'reason' => $summaryReason,
+                'issued_items' => $issuedItems,
                 'fit_test_completed' => $data['fit_test_completed'] ?? null,
                 'authorised_by_user_id' => $data['authorised_by_user_id'],
                 'ppe_returned' => $data['ppe_returned'],
@@ -319,6 +322,7 @@ class PpeFormController extends Controller
             return array_filter([
                 'key' => $item['key'],
                 'qty' => (int) $item['qty'],
+                'reason' => $item['reason'],
                 'size' => ! empty($item['size']) ? $item['size'] : null,
                 'make_model' => ! empty($item['make_model']) ? $item['make_model'] : null,
             ], fn ($v) => $v !== null);

--- a/app/Http/Controllers/PpeRegisterController.php
+++ b/app/Http/Controllers/PpeRegisterController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Location;
 use App\Models\PpeIssuance;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Spatie\Browsershot\Browsershot;
@@ -50,10 +51,12 @@ class PpeRegisterController extends Controller
             $query->withTrashed();
         }
 
-        foreach (['reason', 'source'] as $col) {
-            if ($request->filled($col)) {
-                $query->where($col, $request->input($col));
-            }
+        if ($request->filled('reason')) {
+            $this->applyReasonFilter($query, $request->string('reason')->toString());
+        }
+
+        if ($request->filled('source')) {
+            $query->where('source', $request->input('source'));
         }
 
         $issuances = $query->latest('submitted_at')->paginate($perPage)->withQueryString();
@@ -70,6 +73,7 @@ class PpeRegisterController extends Controller
                 'authorised_by' => $i->authorisedBy ? ['id' => $i->authorisedBy->id, 'name' => $i->authorisedBy->name] : null,
                 'reason' => $i->reason,
                 'reason_label' => $i->reason_label,
+                'reason_labels' => $i->reason_labels,
                 'items_count' => collect($i->issued_items ?? [])->sum(fn ($it) => (int) ($it['qty'] ?? 0)),
                 'ppe_returned' => $i->ppe_returned,
                 'returned_label' => $i->returned_label,
@@ -111,7 +115,7 @@ class PpeRegisterController extends Controller
 
         $catalogByKey = collect(PpeIssuance::PPE_CATALOG)->keyBy('key');
 
-        $items = collect($issuance->issued_items ?? [])->map(function ($it) use ($catalogByKey) {
+        $items = collect($issuance->issued_items ?? [])->map(function ($it) use ($catalogByKey, $issuance) {
             $catalog = $catalogByKey->get($it['key']) ?? null;
 
             return [
@@ -120,6 +124,8 @@ class PpeRegisterController extends Controller
                 'qty' => (int) ($it['qty'] ?? 0),
                 'size' => $it['size'] ?? null,
                 'make_model' => $it['make_model'] ?? null,
+                'reason' => $it['reason'] ?? $issuance->reason,
+                'reason_label' => PpeIssuance::reasonLabel($it['reason'] ?? $issuance->reason),
             ];
         })->values();
 
@@ -175,6 +181,44 @@ class PpeRegisterController extends Controller
         return redirect()->back()->with('success', 'PPE register entry restored.');
     }
 
+    private function applyReasonFilter(Builder $query, string $reason): void
+    {
+        $driver = $query->getConnection()->getDriverName();
+
+        $query->where(function (Builder $query) use ($driver, $reason) {
+            $query->where('reason', $reason);
+
+            if ($driver === 'sqlite') {
+                $query->orWhereRaw(
+                    "exists (select 1 from json_each(ppe_issuances.issued_items) where json_extract(json_each.value, '$.reason') = ?)",
+                    [$reason],
+                );
+
+                return;
+            }
+
+            if ($driver === 'pgsql') {
+                $query->orWhereRaw(
+                    '(ppe_issuances.issued_items)::jsonb @> ?::jsonb',
+                    [json_encode([['reason' => $reason]])],
+                );
+
+                return;
+            }
+
+            if (in_array($driver, ['mysql', 'mariadb'], true)) {
+                $query->orWhereRaw(
+                    "json_search(ppe_issuances.issued_items, 'one', ?, null, '$[*].reason') is not null",
+                    [$reason],
+                );
+
+                return;
+            }
+
+            $query->orWhereJsonContains('issued_items', ['reason' => $reason]);
+        });
+    }
+
     /**
      * Render the printable PPE cabinet QR sheet as a PDF (mirrors toolbox QR sheet style).
      */
@@ -192,7 +236,7 @@ class PpeRegisterController extends Controller
 
         $pdf = $this->renderPdf($html);
 
-        $filename = 'ppe-cabinet-qr-' . ($location->external_id ?: $location->id) . '.pdf';
+        $filename = 'ppe-cabinet-qr-'.($location->external_id ?: $location->id).'.pdf';
 
         return response($pdf, 200, [
             'Content-Type' => 'application/pdf',

--- a/app/Models/PpeIssuance.php
+++ b/app/Models/PpeIssuance.php
@@ -10,6 +10,8 @@ class PpeIssuance extends Model
 {
     use HasUuids, SoftDeletes;
 
+    public const MULTIPLE_REASONS = 'multiple_reasons';
+
     public const REASON_OPTIONS = [
         'new_starter' => 'New Starter',
         'replacement_worn' => 'Replacement - Worn/Damaged',
@@ -29,6 +31,7 @@ class PpeIssuance extends Model
     ];
 
     public const SOURCE_QR = 'qr';
+
     public const SOURCE_KIOSK = 'kiosk';
 
     /**
@@ -84,7 +87,36 @@ class PpeIssuance extends Model
 
     public function getReasonLabelAttribute(): string
     {
-        return self::REASON_OPTIONS[$this->reason] ?? $this->reason;
+        return self::reasonLabel($this->reason);
+    }
+
+    public static function reasonLabel(string $reason): string
+    {
+        if ($reason === self::MULTIPLE_REASONS) {
+            return 'Multiple reasons';
+        }
+
+        return self::REASON_OPTIONS[$reason] ?? $reason;
+    }
+
+    public function getReasonLabelsAttribute(): array
+    {
+        $labels = collect($this->issued_items ?? [])
+            ->map(fn (array $item) => self::reasonLabel($item['reason'] ?? $this->reason))
+            ->unique()
+            ->values()
+            ->all();
+
+        return $labels ?: [self::reasonLabel($this->reason)];
+    }
+
+    public static function summariseItemReasons(array $items): string
+    {
+        $reasons = collect($items)->pluck('reason')->unique()->values();
+
+        return $reasons->count() === 1
+            ? $reasons->first()
+            : self::MULTIPLE_REASONS;
     }
 
     public function getReturnedLabelAttribute(): string

--- a/resources/js/pages/ppe-register/index.tsx
+++ b/resources/js/pages/ppe-register/index.tsx
@@ -1,16 +1,24 @@
 import { SuccessAlertFlash } from '@/components/alert-flash';
-import AppLayout from '@/layouts/app-layout';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
-import { Label } from '@/components/ui/label';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/ui/command';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
-import { Pagination, PaginationContent, PaginationEllipsis, PaginationItem, PaginationLink, PaginationNext, PaginationPrevious } from '@/components/ui/pagination';
-import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/ui/command';
+import { Label } from '@/components/ui/label';
+import {
+    Pagination,
+    PaginationContent,
+    PaginationEllipsis,
+    PaginationItem,
+    PaginationLink,
+    PaginationNext,
+    PaginationPrevious,
+} from '@/components/ui/pagination';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import AppLayout from '@/layouts/app-layout';
 import { type BreadcrumbItem } from '@/types';
 import { Head, Link, router, usePage } from '@inertiajs/react';
 import { Check, ChevronsUpDown, EllipsisVertical, QrCode } from 'lucide-react';
@@ -32,6 +40,7 @@ interface Issuance {
     authorised_by: { id: number; name: string } | null;
     reason: string;
     reason_label: string;
+    reason_labels: string[];
     items_count: number;
     ppe_returned: string;
     returned_label: string;
@@ -168,7 +177,9 @@ export default function PpeRegisterIndex({ location, issuances, filters, reasonO
                                                             setLocationOpen(false);
                                                         }}
                                                     >
-                                                        <Check className={`mr-2 h-3.5 w-3.5 ${loc.id === location.id ? 'opacity-100' : 'opacity-0'}`} />
+                                                        <Check
+                                                            className={`mr-2 h-3.5 w-3.5 ${loc.id === location.id ? 'opacity-100' : 'opacity-0'}`}
+                                                        />
                                                         {loc.name}
                                                     </CommandItem>
                                                 ))}
@@ -226,7 +237,11 @@ export default function PpeRegisterIndex({ location, issuances, filters, reasonO
                                 <Checkbox
                                     checked={showTrashed}
                                     onCheckedChange={(checked) =>
-                                        router.get(baseUrl, { ...queryFilters, trashed: checked ? 1 : undefined }, { preserveState: true, replace: true })
+                                        router.get(
+                                            baseUrl,
+                                            { ...queryFilters, trashed: checked ? 1 : undefined },
+                                            { preserveState: true, replace: true },
+                                        )
                                     }
                                 />
                                 Show trashed ({trashedCount})
@@ -241,7 +256,7 @@ export default function PpeRegisterIndex({ location, issuances, filters, reasonO
                     </div>
                 </div>
 
-                <div className="rounded-md border bg-card">
+                <div className="bg-card rounded-md border">
                     <Table>
                         <TableHeader>
                             <TableRow>
@@ -257,7 +272,7 @@ export default function PpeRegisterIndex({ location, issuances, filters, reasonO
                         <TableBody>
                             {issuances.data.length === 0 ? (
                                 <TableRow>
-                                    <TableCell colSpan={7} className="text-center text-xs text-muted-foreground">
+                                    <TableCell colSpan={7} className="text-muted-foreground text-center text-xs">
                                         No PPE issuances recorded yet for this project.
                                     </TableCell>
                                 </TableRow>
@@ -270,7 +285,7 @@ export default function PpeRegisterIndex({ location, issuances, filters, reasonO
                                                 {i.employee?.name ?? '—'}
                                             </Link>
                                         </TableCell>
-                                        <TableCell className="text-xs">{i.reason_label}</TableCell>
+                                        <TableCell className="max-w-56 text-xs">{i.reason_labels.join(', ')}</TableCell>
                                         <TableCell className="text-xs tabular-nums">{i.items_count}</TableCell>
                                         <TableCell className="text-xs">{i.authorised_by?.name ?? '—'}</TableCell>
                                         <TableCell className="text-xs">
@@ -294,10 +309,7 @@ export default function PpeRegisterIndex({ location, issuances, filters, reasonO
                                                               <DropdownMenuItem onClick={() => restoreIssuance(i)}>Restore</DropdownMenuItem>
                                                           )
                                                         : can('prestarts.delete') && (
-                                                              <DropdownMenuItem
-                                                                  className="text-red-600"
-                                                                  onClick={() => setDeleteTarget(i)}
-                                                              >
+                                                              <DropdownMenuItem className="text-red-600" onClick={() => setDeleteTarget(i)}>
                                                                   Delete
                                                               </DropdownMenuItem>
                                                           )}
@@ -311,7 +323,7 @@ export default function PpeRegisterIndex({ location, issuances, filters, reasonO
                     </Table>
                 </div>
 
-                <div className="flex items-center justify-between text-xs text-muted-foreground">
+                <div className="text-muted-foreground flex items-center justify-between text-xs">
                     <div className="flex items-center gap-2">
                         <span>Per page</span>
                         <Select value={String(issuances.per_page)} onValueChange={(v) => navigate({ per_page: Number(v), page: 1 })}>
@@ -371,7 +383,7 @@ export default function PpeRegisterIndex({ location, issuances, filters, reasonO
                     <DialogHeader>
                         <DialogTitle>Delete PPE register entry?</DialogTitle>
                     </DialogHeader>
-                    <p className="text-sm text-muted-foreground">
+                    <p className="text-muted-foreground text-sm">
                         Entry recorded for <span className="font-medium">{deleteTarget?.employee?.name}</span> on{' '}
                         {deleteTarget?.submitted_at_formatted}. You can restore it from the trashed list.
                     </p>

--- a/resources/js/pages/ppe-register/show.tsx
+++ b/resources/js/pages/ppe-register/show.tsx
@@ -1,5 +1,5 @@
-import AppLayout from '@/layouts/app-layout';
 import { Badge } from '@/components/ui/badge';
+import AppLayout from '@/layouts/app-layout';
 import { type BreadcrumbItem } from '@/types';
 import { Head } from '@inertiajs/react';
 
@@ -9,6 +9,8 @@ type Item = {
     qty: number;
     size: string | null;
     make_model: string | null;
+    reason: string;
+    reason_label: string;
 };
 
 interface Props {
@@ -41,12 +43,12 @@ export default function PpeRegisterShow({ location, issuance }: Props) {
         <AppLayout breadcrumbs={breadcrumbs}>
             <Head title={`PPE — ${issuance.employee?.name ?? 'Entry'}`} />
             <div className="mx-auto w-full max-w-3xl space-y-6 p-4">
-                <div className="rounded-lg border bg-card p-5">
+                <div className="bg-card rounded-lg border p-5">
                     <div className="flex flex-wrap items-start justify-between gap-3">
                         <div>
-                            <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Issued to</p>
+                            <p className="text-muted-foreground text-[11px] font-semibold tracking-wider uppercase">Issued to</p>
                             <h1 className="text-xl font-semibold tracking-tight">{issuance.employee?.full_name ?? '—'}</h1>
-                            <p className="mt-1 text-xs text-muted-foreground">
+                            <p className="text-muted-foreground mt-1 text-xs">
                                 {issuance.submitted_at_formatted} · {location.name}
                             </p>
                         </div>
@@ -63,22 +65,23 @@ export default function PpeRegisterShow({ location, issuance }: Props) {
                     </div>
                 </div>
 
-                <Field label="Reason for issue">{issuance.reason_label}</Field>
-
-                <div className="rounded-lg border bg-card">
+                <div className="bg-card rounded-lg border">
                     <div className="border-b px-5 py-3">
-                        <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">PPE/RPE issued</p>
+                        <p className="text-muted-foreground text-[11px] font-semibold tracking-wider uppercase">PPE/RPE issued</p>
                     </div>
                     <div className="divide-y">
                         {issuance.items.length === 0 ? (
-                            <p className="px-5 py-4 text-sm italic text-muted-foreground">No items recorded.</p>
+                            <p className="text-muted-foreground px-5 py-4 text-sm italic">No items recorded.</p>
                         ) : (
                             issuance.items.map((it) => (
                                 <div key={it.key} className="flex items-center justify-between px-5 py-3">
                                     <div className="flex-1">
                                         <p className="text-sm font-medium">{it.label}</p>
-                                        <p className="text-xs text-muted-foreground">
+                                        <p className="text-muted-foreground text-xs">
                                             {[it.size ? `Size ${it.size}` : null, it.make_model].filter(Boolean).join(' · ')}
+                                        </p>
+                                        <p className="text-muted-foreground mt-1 text-xs">
+                                            Reason: <span className="text-foreground">{it.reason_label}</span>
                                         </p>
                                     </div>
                                     <p className="text-sm font-semibold tabular-nums">×{it.qty}</p>
@@ -102,9 +105,9 @@ export default function PpeRegisterShow({ location, issuance }: Props) {
 
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
     return (
-        <div className="rounded-lg border bg-card px-5 py-4">
-            <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{label}</p>
-            <p className="mt-1 text-sm text-foreground">{children}</p>
+        <div className="bg-card rounded-lg border px-5 py-4">
+            <p className="text-muted-foreground text-[11px] font-semibold tracking-wider uppercase">{label}</p>
+            <p className="text-foreground mt-1 text-sm">{children}</p>
         </div>
     );
 }

--- a/resources/js/pages/ppe-sign-in/components/ppe-form.tsx
+++ b/resources/js/pages/ppe-sign-in/components/ppe-form.tsx
@@ -1,6 +1,6 @@
-import { useMemo, useState } from 'react';
-import { Check, Minus, Plus } from 'lucide-react';
 import { Icon } from '@iconify/react';
+import { Check, Minus, Plus } from 'lucide-react';
+import { useMemo, useState } from 'react';
 
 const CATALOG_ICONS: Record<string, string> = {
     safety_glasses_clear: 'healthicons:ppe-goggles',
@@ -16,15 +16,6 @@ const CATALOG_ICONS: Record<string, string> = {
     other: 'mdi:dots-horizontal-circle-outline',
 };
 
-const REASON_PARENT_ICONS: Record<string, string> = {
-    new_starter: 'mdi:account-plus-outline',
-    replacement: 'mdi:swap-horizontal',
-    additional: 'mdi:plus-circle-outline',
-    project_specific: 'mdi:briefcase-outline',
-    visitor: 'mdi:account-question-outline',
-    other: 'mdi:dots-horizontal-circle-outline',
-};
-
 export type CatalogItem = {
     key: string;
     label: string;
@@ -36,6 +27,7 @@ export type CatalogItem = {
 export type IssuedItem = {
     key: string;
     qty: number;
+    reason: string;
     size?: string;
     make_model?: string;
 };
@@ -50,45 +42,6 @@ export type PpeFormOptions = {
 
 export type PpeFormEndpoints = {
     submit: string;
-};
-
-type ReasonParent = {
-    key: string;
-    label: string;
-    children?: { key: string; label: string }[];
-};
-
-/**
- * Two-step reason picker. Parent keys ending in a leaf (no `children`) submit
- * their own key directly; the `replacement` parent expands a second row of
- * sub-options that submit `replacement_*` keys. The backend accepts any of
- * the 9 leaf keys defined in PpeIssuance::REASON_OPTIONS.
- */
-const REASON_PARENTS: ReasonParent[] = [
-    { key: 'new_starter', label: 'New Starter' },
-    {
-        key: 'replacement',
-        label: 'Replacement',
-        children: [
-            { key: 'replacement_worn', label: 'Worn / Damaged' },
-            { key: 'replacement_lost', label: 'Lost' },
-            { key: 'replacement_stolen', label: 'Stolen' },
-            { key: 'replacement_expired', label: 'Expired' },
-        ],
-    },
-    { key: 'additional', label: 'Additional PPE required' },
-    { key: 'project_specific', label: 'Project specific requirement' },
-    { key: 'visitor', label: 'Visitor / Temporary Worker' },
-    { key: 'other', label: 'Other' },
-];
-
-const parentOfReason = (reason: string): string | null => {
-    if (!reason) return null;
-    for (const p of REASON_PARENTS) {
-        if (p.key === reason) return p.key;
-        if (p.children?.some((c) => c.key === reason)) return p.key;
-    }
-    return null;
 };
 
 type Props = {
@@ -120,8 +73,6 @@ const initialsOf = (name: string) =>
         .toUpperCase();
 
 export default function PpeForm({ employee, pin, options, managers, endpoints, onCancel, onSuccess, hideHeader = false }: Props) {
-    const [reason, setReason] = useState<string>('');
-    const [pendingParent, setPendingParent] = useState<string | null>(null);
     const [items, setItems] = useState<Record<string, IssuedItem>>({});
     const [fitTest, setFitTest] = useState<'yes' | 'no' | null>(null);
     const [authorisedBy, setAuthorisedBy] = useState<number | null>(null);
@@ -132,26 +83,21 @@ export default function PpeForm({ employee, pin, options, managers, endpoints, o
 
     const rpeSelected = useMemo(() => !!items['rpe_half_face'], [items]);
 
-    const activeReasonParent = parentOfReason(reason) ?? pendingParent;
-    const replacementChildren = REASON_PARENTS.find((p) => p.key === 'replacement')?.children ?? [];
-
     const returnedList = useMemo(() => Object.entries(options.returned), [options.returned]);
 
     const canSubmit =
-        !!reason &&
         Object.keys(items).length > 0 &&
         !!authorisedBy &&
         !!returned &&
         acknowledged &&
         (!rpeSelected || fitTest !== null) &&
-        Object.values(items).every(
-            (it) => {
-                const cat = options.catalog.find((c) => c.key === it.key);
-                if (cat?.sizes && cat.sizes.length > 0 && !it.size) return false;
-                if (cat?.requires_make_model && !(it.make_model && it.make_model.trim())) return false;
-                return it.qty > 0;
-            },
-        );
+        Object.values(items).every((it) => {
+            const cat = options.catalog.find((c) => c.key === it.key);
+            if (!it.reason) return false;
+            if (cat?.sizes && cat.sizes.length > 0 && !it.size) return false;
+            if (cat?.requires_make_model && !(it.make_model && it.make_model.trim())) return false;
+            return it.qty > 0;
+        });
 
     const toggleItem = (item: CatalogItem) => {
         setItems((prev) => {
@@ -162,6 +108,7 @@ export default function PpeForm({ employee, pin, options, managers, endpoints, o
                 next[item.key] = {
                     key: item.key,
                     qty: 1,
+                    reason: '',
                     size: item.sizes?.[0],
                 };
             }
@@ -185,10 +132,7 @@ export default function PpeForm({ employee, pin, options, managers, endpoints, o
                     'X-CSRF-TOKEN': csrfToken(),
                 },
                 body: JSON.stringify({
-                    ...(pin !== null
-                        ? { employee_id: employee.id, pin }
-                        : {}),
-                    reason,
+                    ...(pin !== null ? { employee_id: employee.id, pin } : {}),
                     issued_items: Object.values(items),
                     fit_test_completed: rpeSelected ? fitTest === 'yes' : null,
                     authorised_by_user_id: authorisedBy,
@@ -216,7 +160,7 @@ export default function PpeForm({ employee, pin, options, managers, endpoints, o
                         Cancel
                     </button>
                     <div className="text-center">
-                        <p className="text-muted-foreground text-[11px] font-medium uppercase tracking-wider">Collecting as</p>
+                        <p className="text-muted-foreground text-[11px] font-medium tracking-wider uppercase">Collecting as</p>
                         <p className="text-foreground text-sm font-semibold">{employee.name}</p>
                     </div>
                     <div className="w-12" />
@@ -225,60 +169,11 @@ export default function PpeForm({ employee, pin, options, managers, endpoints, o
 
             <div className="flex-1 overflow-y-auto">
                 <div className="mx-auto w-full max-w-3xl space-y-8 px-5 py-6">
-                    <Section number={1} title="Reason for issue">
-                        <div className="grid gap-2 sm:grid-cols-2">
-                            {REASON_PARENTS.map((p) => {
-                                const active = activeReasonParent === p.key;
-                                const iconName = REASON_PARENT_ICONS[p.key];
-                                return (
-                                    <Pill
-                                        key={p.key}
-                                        active={active}
-                                        onClick={() => {
-                                            if (p.children) {
-                                                setPendingParent(p.key);
-                                                if (parentOfReason(reason) !== p.key) setReason('');
-                                            } else {
-                                                setReason(p.key);
-                                                setPendingParent(null);
-                                            }
-                                        }}
-                                    >
-                                        <span className="flex items-center gap-2.5">
-                                            {iconName && (
-                                                <span
-                                                    className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-md transition ${
-                                                        active
-                                                            ? 'bg-background/15 text-background'
-                                                            : 'bg-muted text-muted-foreground'
-                                                    }`}
-                                                >
-                                                    <Icon icon={iconName} width={16} height={16} />
-                                                </span>
-                                            )}
-                                            <span>{p.label}</span>
-                                        </span>
-                                    </Pill>
-                                );
-                            })}
-                        </div>
-                        {activeReasonParent === 'replacement' && (
-                            <div className="bg-muted/40 mt-3 rounded-xl border p-3">
-                                <p className="text-muted-foreground mb-2 text-[11px] font-medium uppercase tracking-wider">
-                                    Replacement reason
-                                </p>
-                                <div className="grid gap-2 sm:grid-cols-2">
-                                    {replacementChildren.map((c) => (
-                                        <Pill key={c.key} active={reason === c.key} onClick={() => setReason(c.key)}>
-                                            {c.label}
-                                        </Pill>
-                                    ))}
-                                </div>
-                            </div>
-                        )}
-                    </Section>
-
-                    <Section number={2} title="PPE/RPE issued" subtitle="Tap each item being issued — set quantity, size, and details. Icons are illustrative only and do not represent the actual PPE supplied.">
+                    <Section
+                        number={1}
+                        title="PPE/RPE issued"
+                        subtitle="Tap each item being issued — set quantity, reason, size, and details. Icons are illustrative only and do not represent the actual PPE supplied."
+                    >
                         <div className="space-y-2">
                             {options.catalog.map((cat) => {
                                 const selected = items[cat.key];
@@ -305,18 +200,34 @@ export default function PpeForm({ employee, pin, options, managers, endpoints, o
                                                 <CatalogIcon catKey={cat.key} active={!!selected} />
                                                 <span className="text-foreground flex-1 text-[15px] font-medium">{cat.label}</span>
                                             </button>
-                                            {selected && (
-                                                <QtyStepper
-                                                    value={selected.qty}
-                                                    onChange={(v) => updateItem(cat.key, { qty: v })}
-                                                />
-                                            )}
+                                            {selected && <QtyStepper value={selected.qty} onChange={(v) => updateItem(cat.key, { qty: v })} />}
                                         </div>
-                                        {selected && ((cat.sizes && cat.sizes.length > 0) || cat.requires_make_model || cat.optional_make_model) && (
+                                        {selected && (
                                             <div className="bg-muted/30 flex flex-wrap items-end gap-3 border-t px-4 py-3">
+                                                <div className="flex min-w-full flex-1 flex-col gap-1 sm:min-w-[280px]">
+                                                    <label
+                                                        htmlFor={`reason-${cat.key}`}
+                                                        className="text-muted-foreground text-[11px] font-medium tracking-wider uppercase"
+                                                    >
+                                                        Reason for issue
+                                                    </label>
+                                                    <select
+                                                        id={`reason-${cat.key}`}
+                                                        value={selected.reason}
+                                                        onChange={(e) => updateItem(cat.key, { reason: e.target.value })}
+                                                        className="bg-card text-foreground border-border focus:border-ring h-10 rounded-md border px-3 text-sm outline-none"
+                                                    >
+                                                        <option value="">Select a reason</option>
+                                                        {Object.entries(options.reasons).map(([key, label]) => (
+                                                            <option key={key} value={key}>
+                                                                {label}
+                                                            </option>
+                                                        ))}
+                                                    </select>
+                                                </div>
                                                 {cat.sizes && cat.sizes.length > 0 && (
                                                     <div className="flex flex-col gap-1">
-                                                        <label className="text-muted-foreground text-[11px] font-medium uppercase tracking-wider">
+                                                        <label className="text-muted-foreground text-[11px] font-medium tracking-wider uppercase">
                                                             Size
                                                         </label>
                                                         <div className="flex gap-1">
@@ -339,7 +250,7 @@ export default function PpeForm({ employee, pin, options, managers, endpoints, o
                                                 )}
                                                 {(cat.requires_make_model || cat.optional_make_model) && (
                                                     <div className="flex flex-1 flex-col gap-1 sm:min-w-[240px]">
-                                                        <label className="text-muted-foreground text-[11px] font-medium uppercase tracking-wider">
+                                                        <label className="text-muted-foreground text-[11px] font-medium tracking-wider uppercase">
                                                             {cat.key === 'other'
                                                                 ? 'Please specify item'
                                                                 : `Make & model${cat.optional_make_model && !cat.requires_make_model ? ' (optional)' : ''}`}
@@ -362,7 +273,7 @@ export default function PpeForm({ employee, pin, options, managers, endpoints, o
                     </Section>
 
                     {rpeSelected && (
-                        <Section number={3} title="Quantitative fit test completed?">
+                        <Section number={2} title="Quantitative fit test completed?">
                             <div className="flex gap-2">
                                 <Pill active={fitTest === 'yes'} onClick={() => setFitTest('yes')}>
                                     Yes
@@ -374,7 +285,7 @@ export default function PpeForm({ employee, pin, options, managers, endpoints, o
                         </Section>
                     )}
 
-                    <Section number={rpeSelected ? 4 : 3} title="Authorised by">
+                    <Section number={rpeSelected ? 3 : 2} title="Authorised by">
                         {managers.length === 0 ? (
                             <p className="border-border bg-muted/40 text-muted-foreground rounded-lg border border-dashed px-4 py-3 text-sm italic">
                                 No supervisors registered for this location.
@@ -409,7 +320,7 @@ export default function PpeForm({ employee, pin, options, managers, endpoints, o
                         )}
                     </Section>
 
-                    <Section number={rpeSelected ? 5 : 4} title="Damaged or worn PPE returned to supervisor?">
+                    <Section number={rpeSelected ? 4 : 3} title="Damaged or worn PPE returned to supervisor?">
                         <div className="flex flex-wrap gap-2">
                             {returnedList.map(([key, label]) => (
                                 <Pill key={key} active={returned === key} onClick={() => setReturned(key)}>
@@ -439,9 +350,7 @@ export default function PpeForm({ employee, pin, options, managers, endpoints, o
                         </div>
                         <p className="text-foreground/80 flex-1 text-[13px] leading-relaxed">{DISCLAIMER}</p>
                     </button>
-                    {error && (
-                        <p className="bg-destructive/10 text-destructive rounded-md px-3 py-2 text-center text-xs font-medium">{error}</p>
-                    )}
+                    {error && <p className="bg-destructive/10 text-destructive rounded-md px-3 py-2 text-center text-xs font-medium">{error}</p>}
                     <button
                         onClick={submit}
                         disabled={!canSubmit || submitting}

--- a/tests/Unit/PpeIssuanceTest.php
+++ b/tests/Unit/PpeIssuanceTest.php
@@ -1,0 +1,121 @@
+<?php
+
+use App\Http\Controllers\PpeFormController;
+use App\Http\Controllers\PpeRegisterController;
+use App\Models\PpeIssuance;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+test('it keeps a shared item reason in the compatibility summary', function () {
+    $items = [
+        ['key' => 'gloves', 'qty' => 2, 'reason' => 'new_starter'],
+        ['key' => 'ear_plugs', 'qty' => 3, 'reason' => 'new_starter'],
+    ];
+
+    expect(PpeIssuance::summariseItemReasons($items))->toBe('new_starter');
+});
+
+test('it marks a compatibility summary when items have different reasons', function () {
+    $items = [
+        ['key' => 'gloves', 'qty' => 2, 'reason' => 'replacement_worn'],
+        ['key' => 'ear_plugs', 'qty' => 3, 'reason' => 'new_starter'],
+    ];
+
+    expect(PpeIssuance::summariseItemReasons($items))
+        ->toBe(PpeIssuance::MULTIPLE_REASONS)
+        ->and(PpeIssuance::reasonLabel(PpeIssuance::MULTIPLE_REASONS))
+        ->toBe('Multiple reasons');
+});
+
+test('it returns unique item reason labels', function () {
+    $issuance = new PpeIssuance([
+        'reason' => PpeIssuance::MULTIPLE_REASONS,
+        'issued_items' => [
+            ['key' => 'gloves', 'qty' => 2, 'reason' => 'replacement_worn'],
+            ['key' => 'ear_plugs', 'qty' => 3, 'reason' => 'new_starter'],
+            ['key' => 'safety_glasses_clear', 'qty' => 1, 'reason' => 'new_starter'],
+        ],
+    ]);
+
+    expect($issuance->reason_labels)->toBe([
+        'Replacement - Worn/Damaged',
+        'New Starter',
+    ]);
+});
+
+test('legacy items fall back to the original issuance reason', function () {
+    $issuance = new PpeIssuance([
+        'reason' => 'project_specific',
+        'issued_items' => [
+            ['key' => 'gloves', 'qty' => 1],
+            ['key' => 'ear_plugs', 'qty' => 2],
+        ],
+    ]);
+
+    expect($issuance->reason_labels)->toBe(['Project specific requirement']);
+});
+
+test('item normalization retains reason and removes blank optional details', function () {
+    $method = new ReflectionMethod(PpeFormController::class, 'normaliseItems');
+    $items = $method->invoke(new PpeFormController, [[
+        'key' => 'gloves',
+        'qty' => '2',
+        'reason' => 'replacement_worn',
+        'size' => '',
+        'make_model' => '',
+    ]]);
+
+    expect($items)->toBe([[
+        'key' => 'gloves',
+        'qty' => 2,
+        'reason' => 'replacement_worn',
+    ]]);
+});
+
+test('register reason filter matches item reasons and historical parent reasons', function () {
+    Schema::create('ppe_issuances', function (Blueprint $table) {
+        $table->string('id')->primary();
+        $table->string('reason');
+        $table->json('issued_items');
+        $table->softDeletes();
+    });
+
+    try {
+        DB::table('ppe_issuances')->insert([
+            [
+                'id' => 'mixed',
+                'reason' => PpeIssuance::MULTIPLE_REASONS,
+                'issued_items' => json_encode([
+                    ['key' => 'gloves', 'qty' => 1, 'reason' => 'replacement_worn'],
+                    ['key' => 'ear_plugs', 'qty' => 1, 'reason' => 'new_starter'],
+                ]),
+            ],
+            [
+                'id' => 'legacy',
+                'reason' => 'replacement_worn',
+                'issued_items' => json_encode([
+                    ['key' => 'gloves', 'qty' => 1],
+                ]),
+            ],
+            [
+                'id' => 'unrelated',
+                'reason' => 'visitor',
+                'issued_items' => json_encode([
+                    ['key' => 'safety_glasses_clear', 'qty' => 1],
+                ]),
+            ],
+        ]);
+
+        $query = PpeIssuance::query();
+        $method = new ReflectionMethod(PpeRegisterController::class, 'applyReasonFilter');
+        $method->invoke(new PpeRegisterController, $query, 'replacement_worn');
+
+        expect($query->orderBy('id')->pluck('id')->all())->toBe(['legacy', 'mixed']);
+    } finally {
+        Schema::dropIfExists('ppe_issuances');
+    }
+});


### PR DESCRIPTION
Updates PPE issuance so each selected item category has its own reason instead of sharing one general reason.

- Adds a reason dropdown to each item.
- Displays item-level reasons in the PPE register.
- Maintains compatibility with existing records.
- No database migration required.
- Tested successfully through the local kiosk flow.